### PR TITLE
updates to SampleIntegration.php

### DIFF
--- a/SampleIntegration.php
+++ b/SampleIntegration.php
@@ -34,7 +34,7 @@
 		$initPaymentRequest = array(
 				"MerchantID"	=>	"[Merchant ID]",
 				"LaneID"	=> 	"02",
-				"Password"	=>	"[Password]",
+				"Password"	=>	'[Password]',
 				"Invoice"	=>	"54321",
 				"TotalAmount"	=>	9.9,
 				"TaxAmount"	=>	0.0,


### PR DESCRIPTION
One small change. [Password] needs to be in single quotes like '[Password]' because the passwords generated by Mercury can contain the $ character and this will not work in PHP with double quotes like "[Password]"

Also, "LaneID" isn't listed as one of the parameters in the current documentation but I don't know if there is another reason for it being there.